### PR TITLE
Fixed batching size for adding blocking info to threat data, and improved config.js description.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -165,8 +165,7 @@ module.exports = {
   name: 'SentinelOne',
   acronym: 'S1',
   description:
-    'The SentinelOne platform delivers the defenses you need to prevent, detect, and ' +
-    "undo—known and unknown—threats. Polarity's SentinelOne integration allows automated " +
+    "Polarity's SentinelOne integration allows automated " +
     'queries of Endpoints and Threats using IP Addresses, URLs, Domains, and Hashes.  ' +
     'This integration allows you to Connect and Disconnect Endpoints from your Network, ' +
     'Add Threats to the Blocklist, and Edit Policy Settings.',


### PR DESCRIPTION
### Bug Explanation
We encountered an issue where our `value_contains` query in `addBlocklistInfoToThreats` in `src/queryThreats.js` had more than 20 found threats being searched for a client at a time, when the api only allows for 20 hashes to be searched at a time on the `/web/api/v2.1/restrictions` endpoint. To fix this I'm chunking `foundThreats` into groups of 19, searching on those chunks in parallel, then flattening the results back together. 

### How to Test
On our test instance we don't have enough foundThreats to trigger the bug, so this will need to be a review making sure I didn't introduce any bugs around threats, and a conceptual review of the code to see if it would actually solve the issue the bug report says.

### Existing Entities with Found Threats
```
830E45CDDC3C096C7A0125C1E5717071F2EC6251
31B827DAD64B2DD881B9F0CEB012E0AC6885492C
192.168.1.51
173.50.120.113
```